### PR TITLE
Make field type 'date' available as target field

### DIFF
--- a/Classes/UserFunc/GetPowermailFields.php
+++ b/Classes/UserFunc/GetPowermailFields.php
@@ -67,7 +67,8 @@ class GetPowermailFields
         'textarea',
         'select',
         'radio',
-        'check'
+        'check',
+        'date'
     ];
 
     /**


### PR DESCRIPTION
Hi, thanks for providing this great extension! Can you please add the field type "date" to the defaultFieldTypes list? At the moment it's not possible to use it as target field.