### PR TITLE
reduce calles to reInitializeParsleyValidation

### DIFF
--- a/Resources/Public/JavaScript/PowermailCondition.js
+++ b/Resources/Public/JavaScript/PowermailCondition.js
@@ -76,6 +76,8 @@
 						}
 					}
 				}
+				
+				reInitializeParsleyValidation();
 			}
 		};
 
@@ -116,7 +118,6 @@
 				$field.removeAttr('data-parsley-required');
 				$field.data('powermailcond-required', 'required');
 			}
-			reInitializeParsleyValidation();
 		};
 
 		/**
@@ -134,7 +135,6 @@
 				}
 			}
 			$field.removeData('powermailcond-required');
-			reInitializeParsleyValidation();
 		};
 
 		/**


### PR DESCRIPTION
Removing the function calls of reInitializeParsleyValidation in derequireField and rerequireField and adding the call in processActions
improves the performance of the validation.

resolves #6