### PR TITLE
[TASK] Solve compose warning due to missing extension key

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,5 +26,10 @@
     "psr-4": {
       "In2code\\PowermailCond\\": "Classes/"
     }
+  },
+  "extra": {
+    "typo3/cms": {
+      "extension-key": "powermail_cond"
+    }
   }
 }


### PR DESCRIPTION
TYPO3 Extension Package "in2code/powermail_cond", does not define extension key in composer.json.
Specifying the extension key will be mandatory in future versions of TYPO3 (see: https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ComposerJson/Index.html#extra)