### PR TITLE
[TASK] Remove TCA configuration showRecordFieldList

### DIFF
--- a/Configuration/TCA/tx_powermailcond_domain_model_condition.php
+++ b/Configuration/TCA/tx_powermailcond_domain_model_condition.php
@@ -20,10 +20,6 @@ return [
             \In2code\PowermailCond\Domain\Model\Condition::TABLE_NAME . '.gif'
         )
     ],
-    'interface' => [
-        'showRecordFieldList' => 'sys_language_uid,l18n_parent,l18n_diffsource,hidden,starttime,
-            endtime,conditioncontainer,title,target_field,actions,filter_select_field,rules,conjunction',
-    ],
     'types' => [
         '1' => [
             'showitem' => 'conditioncontainer, title, target_field, actions, filter_select_field, conjunction, rules'

--- a/Configuration/TCA/tx_powermailcond_domain_model_conditioncontainer.php
+++ b/Configuration/TCA/tx_powermailcond_domain_model_conditioncontainer.php
@@ -21,10 +21,6 @@ return [
             \In2code\PowermailCond\Domain\Model\Condition::TABLE_NAME . '.gif'
         )
     ],
-    'interface' => [
-        'showRecordFieldList' => 'sys_language_uid,l18n_parent,l18n_diffsource,hidden,starttime,' .
-            'endtime,title,form,conditions',
-    ],
     'types' => [
         '1' => ['showitem' => 'title, form, conditions, note'],
     ],

--- a/Configuration/TCA/tx_powermailcond_domain_model_rule.php
+++ b/Configuration/TCA/tx_powermailcond_domain_model_rule.php
@@ -17,9 +17,6 @@ return [
             \In2code\PowermailCond\Domain\Model\Rule::TABLE_NAME . '.gif'
         )
     ],
-    'interface' => [
-        'showRecordFieldList' => 'hidden,conditions,title,start_field,ops,cond_string,equal_field',
-    ],
     'types' => [
         '0' => ['showitem' => 'conditions,title,start_field,ops,cond_string,equal_field']
     ],


### PR DESCRIPTION
The TCA configuration `showRecordFieldList` inside the section `interface` is not evaluated anymore and all occurrences have been removed.

https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/10.3/Feature-88901-RenderAllFieldsInElementInformationController.html